### PR TITLE
change scope of rpc functions to the socket they're called on

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@
               }
             }
           });
-          func.apply(null, data.params);
+          func.apply(socket, data.params);
         } else {
           rpcEmit(null, 'method undefined', data.id);
         }


### PR DESCRIPTION
currently there is no way to know which socket/session that the rpc call is executing for.
